### PR TITLE
🚀 2단계 - 회원가입(뷰)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## 구현 기능 목록
 
 ### 2단계
-- [ ] 사용자 입력 및 유효성 검사에 대해서는 고려하지 않기. 다만 추가할 수 있도록 확장성 열어두기?
-- [ ] 컴포저블 함수가 너무 많은 일을 하지 않도록 분리
-- [ ] Material3 Button, TextField를 활용
-- [ ] 반복 사용되는 TextField를 Composable로 정의하기(UI 요구 사항에 맞는 TextField)
+- [x] 사용자 입력 및 유효성 검사에 대해서는 고려하지 않기. 다만 추가할 수 있도록 확장성 열어두기?
+- [x] 컴포저블 함수가 너무 많은 일을 하지 않도록 분리
+- [x] Material3 Button, TextField를 활용
+- [x] 반복 사용되는 TextField를 Composable로 정의하기(UI 요구 사항에 맞는 TextField)
 - [x] Material Theme 정의하기

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # android-signup
+
+## 구현 기능 목록
+
+### 2단계
+- [ ] 사용자 입력 및 유효성 검사에 대해서는 고려하지 않기. 다만 추가할 수 있도록 확장성 열어두기?
+- [ ] 컴포저블 함수가 너무 많은 일을 하지 않도록 분리
+- [ ] Material3 Button, TextField를 활용
+- [ ] 반복 사용되는 TextField를 Composable로 정의하기(UI 요구 사항에 맞는 TextField)
+- [ ] Material Theme 정의하기

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 - [ ] 컴포저블 함수가 너무 많은 일을 하지 않도록 분리
 - [ ] Material3 Button, TextField를 활용
 - [ ] 반복 사용되는 TextField를 Composable로 정의하기(UI 요구 사항에 맞는 TextField)
-- [ ] Material Theme 정의하기
+- [x] Material Theme 정의하기

--- a/app/src/main/java/nextstep/signup/MainActivity.kt
+++ b/app/src/main/java/nextstep/signup/MainActivity.kt
@@ -3,13 +3,7 @@ package nextstep.signup
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import nextstep.signup.ui.signup.SignUpScreenRoot
 import nextstep.signup.ui.theme.SignupTheme
 
 class MainActivity : ComponentActivity() {
@@ -17,30 +11,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             SignupTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    Greeting("Android")
-                }
+                SignUpScreenRoot()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    SignupTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpAction.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpAction.kt
@@ -1,0 +1,11 @@
+package nextstep.signup.ui.signup
+
+sealed interface SignUpAction {
+
+    data class OnUsernameChanged(val value: String): SignUpAction
+    data class OnEmailChanged(val value: String): SignUpAction
+    data class OnPasswordChanged(val value: String): SignUpAction
+    data class OnPasswordConfirmChanged(val value: String): SignUpAction
+    data object OnSignUpClick: SignUpAction
+    data object None: SignUpAction
+}

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -37,6 +37,7 @@ fun SignUpScreenRoot(modifier: Modifier = Modifier) {
     }
 
     SignUpScreen(
+        modifier = modifier,
         state = state,
         onAction = { action ->
             when (action) {

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package nextstep.signup.ui.signup
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -121,6 +123,19 @@ fun SignUpScreen(
                     keyboardOptions = KeyboardOptions(
                         imeAction = ImeAction.Next
                     )
+                )
+            }
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusable(enabled = true),
+                onClick = {
+                    onAction(SignUpAction.OnSignUpClick)
+                }
+            ) {
+                Text(
+                    text = stringResource(R.string.sign_up_sign),
+                    modifier = Modifier.padding(vertical = 8.dp),
                 )
             }
         }

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -95,7 +95,7 @@ fun SignUpScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                modifier = Modifier.padding(top = 48.dp),
+                modifier = Modifier.padding(top = 48.dp, bottom = 6.dp),
                 text = stringResource(R.string.sign_up_welcome),
                 fontWeight = FontWeight.Bold,
                 fontSize = 26.sp,
@@ -107,6 +107,7 @@ fun SignUpScreen(
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(top = 6.dp)
                     .focusable(enabled = true),
                 onClick = {
                     onAction(SignUpAction.OnSignUpClick)
@@ -139,7 +140,7 @@ fun InputFields(
             },
             visualTransformation = inputState.visualTransformation,
             onValueChange = {
-                onAction(inputState.onValueChange( it))
+                onAction(inputState.onValueChange(it))
             },
             keyboardActions = KeyboardActions(
                 onNext = {

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -85,8 +85,6 @@ fun SignUpScreen(
     onAction: (SignUpAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val focusManager = LocalFocusManager.current
-
     Scaffold { paddingValues ->
         Column(
             modifier = modifier
@@ -102,29 +100,10 @@ fun SignUpScreen(
                 fontWeight = FontWeight.Bold,
                 fontSize = 26.sp,
             )
-            for (inputState in state.getInputStateList()) {
-                TextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    value = inputState.value,
-                    label = {
-                        if (inputState.label != null) {
-                            Text(stringResource(inputState.label))
-                        }
-                    },
-                    visualTransformation = inputState.visualTransformation,
-                    onValueChange = {
-                        onAction(inputState.onValueChange( it))
-                    },
-                    keyboardActions = KeyboardActions(
-                        onNext = {
-                            focusManager.moveFocus(FocusDirection.Next)
-                        }
-                    ),
-                    keyboardOptions = KeyboardOptions(
-                        imeAction = ImeAction.Next
-                    )
-                )
-            }
+            InputFields(
+                inputStates = state.getInputStateList(),
+                onAction = onAction,
+            )
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -139,6 +118,38 @@ fun SignUpScreen(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun InputFields(
+    inputStates: List<InputState>,
+    onAction: (SignUpAction) -> Unit,
+) {
+    val focusManager = LocalFocusManager.current
+
+    for (inputState in inputStates) {
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = inputState.value,
+            label = {
+                if (inputState.label != null) {
+                    Text(stringResource(inputState.label))
+                }
+            },
+            visualTransformation = inputState.visualTransformation,
+            onValueChange = {
+                onAction(inputState.onValueChange( it))
+            },
+            keyboardActions = KeyboardActions(
+                onNext = {
+                    focusManager.moveFocus(FocusDirection.Next)
+                }
+            ),
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
+        )
     }
 }
 

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -1,0 +1,115 @@
+package nextstep.signup.ui.signup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import nextstep.signup.ui.theme.SignupTheme
+
+@Composable
+fun SignUpScreenRoot(modifier: Modifier = Modifier) {
+    var state by remember {
+        mutableStateOf(SignUpState())
+    }
+
+    SignUpScreen(
+        state = state,
+        onAction = { action ->
+            when (action) {
+                is SignUpAction.OnEmailChanged -> {
+                    state = state.copy(
+                        email = state.email.copy(
+                            value = action.value
+                        ),
+                    )
+                }
+
+                is SignUpAction.OnPasswordChanged -> {
+                    state = state.copy(
+                        password = state.password.copy(
+                            value = action.value
+                        ),
+                    )
+                }
+
+                is SignUpAction.OnPasswordConfirmChanged -> {
+                    state = state.copy(
+                        passwordConfirm = state.passwordConfirm.copy(
+                            value = action.value
+                        ),
+                    )
+                }
+
+                SignUpAction.OnSignUpClick -> {}
+                is SignUpAction.OnUsernameChanged -> {
+                    state = state.copy(
+                        userName = state.userName.copy(
+                            value = action.value
+                        ),
+                    )
+                }
+
+                SignUpAction.None -> {}
+            }
+        }
+    )
+}
+
+@Composable
+fun SignUpScreen(
+    state: SignUpState,
+    onAction: (SignUpAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold { paddingValues ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(36.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            for (inputState in state.getInputStateList()) {
+                TextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = inputState.value,
+                    label = {
+                        if (inputState.label != null) {
+                            Text(stringResource(inputState.label))
+                        }
+                    },
+                    visualTransformation = inputState.visualTransformation,
+                    onValueChange = {
+                        onAction(inputState.onValueChange(it))
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SignUpScreenPreview() {
+    SignupTheme {
+        SignUpScreen(
+            state = SignUpState(),
+            onAction = {},
+        )
+    }
+}

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -15,7 +17,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import nextstep.signup.ui.theme.SignupTheme
@@ -75,6 +80,8 @@ fun SignUpScreen(
     onAction: (SignUpAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val focusManager = LocalFocusManager.current
+
     Scaffold { paddingValues ->
         Column(
             modifier = modifier
@@ -95,8 +102,16 @@ fun SignUpScreen(
                     },
                     visualTransformation = inputState.visualTransformation,
                     onValueChange = {
-                        onAction(inputState.onValueChange(it))
-                    }
+                        onAction(inputState.onValueChange( it))
+                    },
+                    keyboardActions = KeyboardActions(
+                        onNext = {
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
+                    ),
+                    keyboardOptions = KeyboardOptions(
+                        imeAction = ImeAction.Next
+                    )
                 )
             }
         }

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpScreen.kt
@@ -20,9 +20,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import nextstep.signup.R
 import nextstep.signup.ui.theme.SignupTheme
 
 @Composable
@@ -91,6 +94,12 @@ fun SignUpScreen(
             verticalArrangement = Arrangement.spacedBy(36.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Text(
+                modifier = Modifier.padding(top = 48.dp),
+                text = stringResource(R.string.sign_up_welcome),
+                fontWeight = FontWeight.Bold,
+                fontSize = 26.sp,
+            )
             for (inputState in state.getInputStateList()) {
                 TextField(
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/nextstep/signup/ui/signup/SignUpState.kt
+++ b/app/src/main/java/nextstep/signup/ui/signup/SignUpState.kt
@@ -1,0 +1,46 @@
+package nextstep.signup.ui.signup
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import nextstep.signup.R
+
+data class SignUpState(
+    val userName: InputState = InputState(
+        label = R.string.username_label,
+        onValueChange = {
+            SignUpAction.OnUsernameChanged(it)
+        }
+    ),
+    val email: InputState = InputState(
+        label = R.string.email_label,
+        onValueChange = {
+            SignUpAction.OnEmailChanged(it)
+        }
+    ),
+    val password: InputState = InputState(
+        label = R.string.password_label,
+        visualTransformation = PasswordVisualTransformation(),
+        onValueChange = {
+            SignUpAction.OnPasswordChanged(it)
+        }
+    ),
+    val passwordConfirm: InputState = InputState(
+        label = R.string.password_confirm_label,
+        visualTransformation = PasswordVisualTransformation(),
+        onValueChange = {
+            SignUpAction.OnPasswordConfirmChanged(it)
+        }
+    ),
+) {
+    fun getInputStateList() = listOf(userName, email, password, passwordConfirm)
+}
+
+data class InputState(
+    @StringRes val label: Int? = null,
+    val value: String = "",
+    val visualTransformation: VisualTransformation = VisualTransformation.None,
+    val onValueChange: (String) -> SignUpAction = {
+        SignUpAction.None
+    },
+)

--- a/app/src/main/java/nextstep/signup/ui/theme/Theme.kt
+++ b/app/src/main/java/nextstep/signup/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package nextstep.signup.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,11 +8,8 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -22,26 +18,18 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
+    primary = Color(0xFF2196F3),
     secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    tertiary = Pink40,
+    background = Color.White,
+    surfaceContainerHighest = Color(0xFFE3E8F1),
 )
 
 @Composable
 fun SignupTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Signup</string>
+    <string name="username_label">Username</string>
+    <string name="email_label">Email</string>
+    <string name="password_label">Password</string>
+    <string name="password_confirm_label">Password Confirm</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="email_label">Email</string>
     <string name="password_label">Password</string>
     <string name="password_confirm_label">Password Confirm</string>
+    <string name="sign_up_welcome">Welcome to Compose 🚀</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="password_label">Password</string>
     <string name="password_confirm_label">Password Confirm</string>
     <string name="sign_up_welcome">Welcome to Compose 🚀</string>
+    <string name="sign_up_sign">Sign Up</string>
 </resources>


### PR DESCRIPTION
## 고민한 내용
- TextField가 4번 반복되는데, for 문을 이용해 반복되는 TextField Composable 코드를 줄이고자 TextField에 설정할 값을 State로 분리했습니다.
 각 TextField의 UI 요구 사항이 변경되면(예를 들어, TextField가 아닌 다른 Composable을 요구함), state에 Composable을 slot API 형식으로 정의하는 속성도 추가해야 하는데, 이것은 state라는 목적에 부합하지 않다고 생각합니다. 하지만 이번 미션에서 UI 요구사항은 고정되어 있어 문제가 안 된다고 생각했습니다.
 또한 아직 발생하지 않은, 발생할 가능성이 적은 미래를 예측해서 코드를 작성하는 것보다 현재의 요구사항에 최선의 코드를 작성하는 것이 베스트라고 생각했고, TextField를 for 문을 이용해 코드를 줄이는 것이 베스트라고 생각해서 이렇게 구현했습니다.
- Material Theme을 이용해 색상을 적용했습니다. 어떤 색상을 설정할지는 [Mateiral 홈페이지에 Composable spec 시트](https://m3.material.io/components/text-fields/specs#6c3985d7-37d9-4aaa-b03e-7fa616bb009c)를 보고 정의했습니다. 지금은 한 화면 밖에 없어서 문제가 없었지만, 화면이 많아질수록 각 Composable에서 요구하는 primary, surface 색상이 다른 경우가 많아서 theme 만을 활용해 구현하는 것이 어려웠습니다. 현업에서는 Theme의 primary, secondary 등만을 이용해서 구현하지 않고, 별도의 Custom Color를 정의해서 구현하나요?

사소한 것도 코멘트 남겨주시면 고민해보고 학습하겠습니다.(시간 빌게이츠 입니다😀) 감사합니다.