### PR TITLE
🚀 2단계 - 회원가입(뷰)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # android-signup
+
+🚀 2단계 - 회원가입(뷰)
+- TextField 컴포넌트 작성
+- Button 컴포넌트 작성
+- SignUpScreen 구현

--- a/app/src/main/java/nextstep/signup/MainActivity.kt
+++ b/app/src/main/java/nextstep/signup/MainActivity.kt
@@ -17,30 +17,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             SignupTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    Greeting("Android")
-                }
+                SignUpScreen()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    SignupTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/nextstep/signup/SignUpButton.kt
+++ b/app/src/main/java/nextstep/signup/SignUpButton.kt
@@ -1,0 +1,45 @@
+package nextstep.signup
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import nextstep.signup.ui.theme.Blue50
+import nextstep.signup.ui.theme.SignupTheme
+
+@Composable
+fun SignUpButton(
+    text: String,
+    textStyle: TextStyle = MaterialTheme.typography.labelLarge,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Button(
+        modifier = modifier.fillMaxWidth().height(50.dp),
+        onClick = onClick,
+        content = {
+            Text(text = text, style = textStyle)
+        },
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Blue50
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun SignUpButtonPreview() {
+    SignupTheme {
+        SignUpButton(
+            text = "Sign Up",
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/nextstep/signup/SignUpScreen.kt
+++ b/app/src/main/java/nextstep/signup/SignUpScreen.kt
@@ -1,0 +1,91 @@
+package nextstep.signup
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import nextstep.signup.ui.theme.SignupTheme
+
+@Composable
+fun SignUpScreen() {
+    var userName by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var passwordConfirm by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.White)
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        Text(
+            modifier = Modifier.padding(top = 112.dp),
+            text = stringResource(R.string.sign_up_title),
+            color = Color.Black,
+            fontWeight = FontWeight.Bold,
+            fontSize = 26.sp,
+            lineHeight = 20.sp,
+            letterSpacing = 1.sp
+        )
+
+        SignUpTextField(
+            value = userName,
+            label = stringResource(R.string.sign_up_user_name),
+            onValueChange = { userName = it }
+        )
+
+        SignUpTextField(
+            value = email,
+            label = stringResource(R.string.sign_up_email),
+            onValueChange = { email = it }
+        )
+
+        SignUpTextField(
+            value = password,
+            label = stringResource(R.string.sign_up_password),
+            visualTransformation = PasswordVisualTransformation(),
+            onValueChange = { password = it }
+        )
+
+        SignUpTextField(
+            value = passwordConfirm,
+            label = stringResource(R.string.sign_up_password_confirm),
+            visualTransformation = PasswordVisualTransformation(),
+            onValueChange = { passwordConfirm = it }
+        )
+
+        SignUpButton(
+            text = stringResource(R.string.sign_up),
+            onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SignUpScreenPreview() {
+    SignupTheme {
+        SignUpScreen()
+    }
+}

--- a/app/src/main/java/nextstep/signup/SignUpTextField.kt
+++ b/app/src/main/java/nextstep/signup/SignUpTextField.kt
@@ -1,0 +1,74 @@
+package nextstep.signup
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import nextstep.signup.ui.theme.Blue50
+import nextstep.signup.ui.theme.BlueGrey20
+import nextstep.signup.ui.theme.SignupTheme
+
+@Composable
+fun SignUpTextField(
+    value: String,
+    label: String,
+    supportingText: String = "",
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false,
+    textStyle: TextStyle = MaterialTheme.typography.bodyLarge,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+) {
+    TextField(
+        modifier = modifier.fillMaxWidth().height(56.dp),
+        value = value,
+        isError = isError,
+        onValueChange = onValueChange,
+        textStyle = textStyle,
+        label = {
+            Text(text = label)
+        },
+        supportingText = {
+            if (isError) {
+                Text(text = supportingText)
+            }
+        },
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = BlueGrey20,
+            unfocusedContainerColor = BlueGrey20,
+            errorContainerColor = BlueGrey20,
+            cursorColor = Blue50,
+            focusedIndicatorColor = Blue50,
+            focusedLabelColor = Blue50
+        ),
+        visualTransformation = visualTransformation
+    )
+}
+
+@Preview
+@Composable
+private fun SignUpTextFieldPreview() {
+    SignupTheme {
+        var text by remember { mutableStateOf("") }
+        Column {
+            SignUpTextField(
+                value = text,
+                label = "Username",
+                onValueChange = { text = it }
+            )
+        }
+    }
+}

--- a/app/src/main/java/nextstep/signup/ui/theme/Color.kt
+++ b/app/src/main/java/nextstep/signup/ui/theme/Color.kt
@@ -9,3 +9,6 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+
+val BlueGrey20 = Color(0xFFE3E8F1)
+val Blue50 = Color(0xFF2196F3)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">Signup</string>
+    <string name="sign_up_title">Welcome to Compose 🚀</string>
+    <string name="sign_up_user_name">Username</string>
+    <string name="sign_up_email">Email</string>
+    <string name="sign_up_password">Password</string>
+    <string name="sign_up_password_confirm">Password Confirm</string>
+    <string name="sign_up">Sign Up</string>
 </resources>


### PR DESCRIPTION
🚀 2단계 - 회원가입(뷰)
- TextField 컴포넌트 작성
- Button 컴포넌트 작성
- SignUpScreen 구현

---


<img src="https://github.com/user-attachments/assets/920a8e58-c09a-4eaa-9cf1-cead281f90db" width="300"/>

---
### 고민했던 부분
- 피그마 시트에서는 `Blue50`, `BlueGrey20` 색상만 정의되어 있고, 다른 색상(ex. TextField 텍스트 색상, 에러 색상)들은 정의가 되어 있지 않아서 눈치껏 MaterialTheme 색상을 그대로 사용하는 것으로 판단하여 UI 구성했습니다.
